### PR TITLE
android側に、PlainTextのセット

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Install the plugin using the CLI, for instance with PhoneGap:
 
 	cordova plugin add https://github.com/Anuj-Raghuvanshi/cordova-clipboard-plugin
 
-The plugin creates the object `cordova.plugins.clipboard` with the methods `copy(text, onSuccess, onError)` and `paste(onSuccess, onError)`.
+The plugin creates the object `cordova.plugins.clipboard` with the methods `copy(text, plainText,onSuccess, onError)` and `paste(onSuccess, onError)`.
 
 Example:
 
 	var text = "Hello World!";
 
-	cordova.plugins.clipboard.copy(text);
+	cordova.plugins.dejirenClipboard.copy(text, plainText);
 
-	cordova.plugins.clipboard.paste(function (text) { alert(text); });
+	cordova.plugins.clipboard.paste(function (text, plainText) { alert(text); });
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cordova-clipboard-plugin",
-    "version": "0.0.3",
-    "description": "Clipboard management plugin for Cordova/PhoneGap",
+    "version": "0.0.4",
+    "description": "Clipboard management plugin for Dejiren Cordova/PhoneGap",
     "cordova": {
         "id": "com.verso.cordova.clipboard",
         "platforms": [
@@ -21,10 +21,12 @@
         "cordova-ios",
         "cordova-android"
     ],
-    "engines": [{
-        "name": "cordova",
-        "version": ">=3.0.0"
-    }],
+    "engines": [
+        {
+            "name": "cordova",
+            "version": ">=3.0.0"
+        }
+    ],
     "author": "",
     "license": "MIT",
     "bugs": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
     <license>MIT</license>
 
     <js-module src="www/clipboard.js" name="Clipboard">
-        <clobbers target="cordova.plugins.clipboard" />
+        <clobbers target="cordova.plugins.dejirenClipboard" />
     </js-module>
 
     <!-- iOS -->

--- a/src/android/Clipboard.java
+++ b/src/android/Clipboard.java
@@ -25,9 +25,13 @@ public class Clipboard extends CordovaPlugin {
         if (action.equals(actionCopy)) {
             try {
                 String text = args.getString(0);
-                //ClipData clip = ClipData.newPlainText("Text", text);
-                String plainText = Html.fromHtml(text).toString();
-                ClipData clip = ClipData.newHtmlText("html", plainText, text);
+                String plainText = args.getString(1);
+                ClipData clip;
+                if(text == plainText) {
+                   clip  = ClipData.newPlainText("Text", plainText);
+                } else {
+                   clip = ClipData.newHtmlText("html", plainText, text);
+                }
                 clipboard.setPrimaryClip(clip);
                 callbackContext.success(text);
 

--- a/www/clipboard.js
+++ b/www/clipboard.js
@@ -1,22 +1,25 @@
-var cordova = require('cordova');
+var cordova = require("cordova");
 
 /**
  * Clipboard plugin for Cordova
- * 
+ *
  * @constructor
  */
-function Clipboard () {}
+function Clipboard() {}
 
 /**
  * Sets the clipboard content
  *
- * @param {String}   text      The content to copy to the clipboard
+ * @param {String}   text      The content to copy to the clipboard  for text/html MIME type
+ * @param {String}   plainText The plain text  to copy to the clipboard for text/plain MIME type
  * @param {Function} onSuccess The function to call in case of success (takes the copied text as argument)
  * @param {Function} onFail    The function to call in case of error
  */
-Clipboard.prototype.copy = function (text, onSuccess, onFail) {
-    if (typeof text === "undefined" || text === null) text = "";
-	cordova.exec(onSuccess, onFail, "Clipboard", "copy", [text]);
+Clipboard.prototype.copy = function (text, plainText, onSuccess, onFail) {
+  if (typeof text === "undefined" || text === null) text = "";
+  if (typeof plainText === "undefined" || plainText === null) plainText = "";
+
+  cordova.exec(onSuccess, onFail, "Clipboard", "copy", [text, plainText]);
 };
 
 /**
@@ -26,7 +29,7 @@ Clipboard.prototype.copy = function (text, onSuccess, onFail) {
  * @param {Function} onFail    The function to call in case of error
  */
 Clipboard.prototype.paste = function (onSuccess, onFail) {
-	cordova.exec(onSuccess, onFail, "Clipboard", "paste", []);
+  cordova.exec(onSuccess, onFail, "Clipboard", "paste", []);
 };
 
 // Register the plugin


### PR DESCRIPTION
以下のパターンを対応します。
- PlainTextとHtmlTextの変換がプラグインの外で行ってPlainTextをセットしたい。

引数に、plainTextを追加して、text/plainにセットします。
plainTextとHtmlTextが同じ場合、text/plainとみなします。

dejirenでは、android側のみ使用していますので、android側のみを修正

